### PR TITLE
Poetry now requires minimum version 1.2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,15 +40,3 @@ coverage:
 		--cov=src/bundle_media \
 		tests/
 	$(OPEN) coverage/index.html
-
-.PHONY: run
-run:
-	$(PYTHON) runner.py
-
-.PHONY: create_app
-create_app:
-	$(PYTHON) create_app.py
-
-.PHONY: publish_queue
-publish_queue:
-	$(PYTHON) publish_queue.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,5 +55,5 @@ omit = [
 ]
 
 [build-system]
-requires = ['poetry-core~=1.0']
+requires = ['poetry-core>=1.2.0']
 build-backend = 'poetry.core.masonry.api'


### PR DESCRIPTION
Trying to fix a run failure:
```
RuntimeError

  The Poetry configuration is invalid:
    - Additional properties are not allowed ('group' was unexpected)
```

Found that Poetry needs to be bumped to minimum 1.2.0:
https://stackoverflow.com/questions/73876790/poetry-configuration-is-invalid-additional-properties-are-not-allowed-group

Setting it up in the libs, hoping that consumers react