### PR TITLE
Emulate a Mastodon API wrapper for Firefish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.4.0
+
+- Add `firefish` class as a wrapper for the Firefish API calls that I need
+
 # v0.3.3
 
 - Bump PyYaml to version 6.0.1 as 6.0 is broken

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v0.4.0
 
 - Add `firefish` class as a wrapper for the Firefish API calls that I need
+- Add a `logger.get_logger()` and mark `logger.getLogger()` as deprecated, to be removed in v0.5.0
 
 # v0.3.3
 

--- a/NEXT_MAJOR.md
+++ b/NEXT_MAJOR.md
@@ -1,5 +1,4 @@
 # Changes queued for next marjor version
 These are changes identified as needed but deferred to the next bumped major version. The reason is that some of the changes here introduce a breaking change that per see can't be defended as needed (maybe just aestethincs) but once they are accummulated makes sense to bump a major version.
 
-## 1. Rename `Logger.getLogger()` to `Logger.get_logger()`
-As it was one of the initial classes in this package, it got inspired by the official `logging.getLogger()`. After some time I realized that it causes sometimes confusion (_is it the official one or the one from my package?_) and also I do try to implement [the Python conventions](https://peps.python.org/pep-0008/#method-names-and-instance-variables) everyehere.
+*The list is empty*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyxavi"
-version = "0.3.3"
+version = "0.4.0"
 description = "Set of utilities to assist on simple Python projects"
 authors = ["Xavier Arnaus <xavi@arnaus.net>"]
 readme = "README.md"

--- a/pyxavi/__init__
+++ b/pyxavi/__init__
@@ -4,12 +4,15 @@ from .storage import Storage
 from .debugger import dd, traceback
 from .media import Media
 from .terminal_color import TerminalColor
+from .firefish import Firefish
 
 __all__ = [
     "Config",
     "Logger",
     "Storage",
-    "dd", "traceback"
+    "dd", 
+    "traceback",
     "Media",
-    "TerminalColor"
+    "TerminalColor",
+    "Firefish"
 ]

--- a/pyxavi/firefish.py
+++ b/pyxavi/firefish.py
@@ -6,8 +6,8 @@ class Firefish:
     api_base_url: str = None
     client_name = None
 
-    
-    def create_app(self, client_name: str, api_base_url: str, to_file: str):
+    @staticmethod
+    def create_app(client_name: str, api_base_url: str, to_file: str):
         '''
         Do we even need to register the app?
         Not really, but this approach help us to define the API url and have it stored in a file.

--- a/pyxavi/firefish.py
+++ b/pyxavi/firefish.py
@@ -150,6 +150,9 @@ class Firefish:
         '''
         ENDPOINT = "api/notes/create"
 
+        if status is None:
+            raise RuntimeError("Field 'status' is mandatory")
+
         # Text is mandatory
         json_data = {
             "text": status,

--- a/pyxavi/firefish.py
+++ b/pyxavi/firefish.py
@@ -1,3 +1,4 @@
+from .debugger import dd
 import requests
 
 class Firefish:
@@ -81,9 +82,6 @@ class Firefish:
                 file.write(self.client_name + "\n")
                 file.write(self.bearer_token + "\n")
 
-        
-        
-    
     def __post_call(self, endpoint: str, headers: dict = {}, json: str = None):
         response = requests.post(
             url = f"{self.api_base_url}/{endpoint}",
@@ -95,6 +93,8 @@ class Firefish:
             },
             json=json
         )
+
+        dd(response)
 
         if response.status_code == 200:
             return response.content

--- a/pyxavi/firefish.py
+++ b/pyxavi/firefish.py
@@ -28,10 +28,11 @@ class Firefish:
             file.write(client_name + "\n")
 
 
-    def __init__(self, client_id: str = None, access_token: str = None):
+    def __init__(self, client_id: str = None, api_base_url: str = None, access_token: str = None):
         '''
         If client_id comes we expect to find a file called like client_id which contains the api_base_url.
         If access_token comes we expect to find a file called like access_token which contains both api_base_url and the user token from login.
+        If api_base_url comes we just take it.
 
         This is just to emulate the 2 step init that we have with Mastodon.py
         '''
@@ -43,11 +44,18 @@ class Firefish:
                 self.client_name = file.readline()
 
         # So we received an access_token, this is actually a filename so read it and get the params.
-        if client_id is not None:
-            with open(client_id, 'r') as file:
+        if access_token is not None:
+            with open(access_token, 'r') as file:
                 self.api_base_url = file.readline()
                 self.client_name = file.readline()
                 self.bearer_token = file.readline()
+        
+        if api_base_url is not None:
+            self.api_base_url = api_base_url
+        
+        # If we don't have a client_name, means that nothing came with. Error!
+        if self.client_name is None:
+            raise RuntimeError("Mandatory params not found. Did you specify client_id or access_token?")
 
 
     def log_in(self, username: str = None, password: str = None, to_file: str = None):

--- a/pyxavi/firefish.py
+++ b/pyxavi/firefish.py
@@ -28,11 +28,16 @@ class Firefish:
             file.write(client_name + "\n")
 
 
-    def __init__(self, client_id: str = None, api_base_url: str = None, access_token: str = None):
+    def __init__(self,
+                 client_id: str = None,
+                 api_base_url: str = None,
+                 access_token: str = None,
+                 feature_set: str = None):
         '''
         If client_id comes we expect to find a file called like client_id which contains the api_base_url.
         If access_token comes we expect to find a file called like access_token which contains both api_base_url and the user token from login.
         If api_base_url comes we just take it.
+        We just ignore feature_set.
 
         This is just to emulate the 2 step init that we have with Mastodon.py
         '''

--- a/pyxavi/firefish.py
+++ b/pyxavi/firefish.py
@@ -18,6 +18,11 @@ class Firefish:
             - Write the api_base_url
         '''
 
+        if client_name is None or \
+            api_base_url is None or \
+            to_file is None:
+            raise RuntimeError("All params are mandatory")
+
         # Clean the given API base URL before keeping it in mem.
         if api_base_url[-1] == "/":
             api_base_url = api_base_url[:-1]

--- a/pyxavi/firefish.py
+++ b/pyxavi/firefish.py
@@ -1,5 +1,6 @@
 import requests
 
+
 class Firefish:
 
     bearer_token: str = None
@@ -32,12 +33,13 @@ class Firefish:
             file.write(api_base_url + "\n")
             file.write(client_name)
 
-
-    def __init__(self,
-                 client_id: str = None,
-                 api_base_url: str = None,
-                 access_token: str = None,
-                 feature_set: str = None):
+    def __init__(
+        self,
+        client_id: str = None,
+        api_base_url: str = None,
+        access_token: str = None,
+        feature_set: str = None
+    ):
         '''
         If client_id comes we expect to find a file called like client_id which contains the api_base_url.
         If access_token comes we expect to find a file called like access_token which contains both api_base_url and the user token from login.
@@ -59,14 +61,15 @@ class Firefish:
                 self.api_base_url = file.readline().strip()
                 self.client_name = file.readline().strip()
                 self.bearer_token = file.readline().strip()
-        
+
         if api_base_url is not None:
             self.api_base_url = api_base_url
-        
+
         # If we don't have a client_name, means that nothing came with. Error!
         if self.client_name is None and self.api_base_url is None:
-            raise RuntimeError("Mandatory params not found. Did you specify client_id or access_token?")
-
+            raise RuntimeError(
+                "Mandatory params not found. Did you specify client_id or access_token?"
+            )
 
     def log_in(self, username: str = None, password: str = None, to_file: str = None):
         '''
@@ -76,8 +79,10 @@ class Firefish:
         If the to_file param is filled, we want to save the authentication into a file.
         '''
         if password is None:
-            raise RuntimeError("I need a Bearer token set into the 'password' param. Generate it and give it to me!")
-        
+            raise RuntimeError(
+                "I need a Bearer token set into the 'password' param. Generate it and give it to me!"
+            )
+
         self.bearer_token = password
 
         if to_file is not None:
@@ -91,10 +96,9 @@ class Firefish:
         This is the method that proxies (and builds) all API POST calls.
         '''
         response = requests.post(
-            url = f"{self.api_base_url}/{endpoint}",
+            url=f"{self.api_base_url}/{endpoint}",
             headers={
-                **headers,
-                **{
+                **headers, **{
                     'Authorization': 'Bearer ' + self.bearer_token,
                 }
             },
@@ -104,21 +108,25 @@ class Firefish:
         if response.status_code == 200:
             return response.content
         else:
-            raise RuntimeError(f"API Request ERROR -> {response.status_code}: {response.reason}")
+            raise RuntimeError(
+                f"API Request ERROR -> {response.status_code}: {response.reason}"
+            )
 
-    def status_post(self, 
-                    status: str,
-                    in_reply_to_id=None,
-                    media_ids=None,
-                    sensitive=False,
-                    visibility=None,
-                    spoiler_text=None,
-                    language=None,
-                    idempotency_key=None,
-                    content_type=None,
-                    scheduled_at=None,
-                    poll=None,
-                    quote_id=None):
+    def status_post(
+        self,
+        status: str,
+        in_reply_to_id=None,
+        media_ids=None,
+        sensitive=False,
+        visibility=None,
+        spoiler_text=None,
+        language=None,
+        idempotency_key=None,
+        content_type=None,
+        scheduled_at=None,
+        poll=None,
+        quote_id=None
+    ):
         '''
         Post a status. Can optionally be in reply to another status and contain media.
 
@@ -166,24 +174,20 @@ class Firefish:
         if visibility is not None:
             # Translate the values from Mastodon to Firefish
             firefish_values_by_mastodon = {
-                "public": "public",
-                #"": "home",
+                "public": "public",  #"": "home",
                 "private": "followers",
                 "direct": "specified",
                 "unlisted": "hidden"
             }
             json_data["visibility"] = firefish_values_by_mastodon[visibility]
-        
+
         # Do we define the language?
         if language is not None:
             json_data["lang"] = language
-        
+
         # Is this a reply to another status?
         if in_reply_to_id is not None:
             json_data["replyId"] = in_reply_to_id
-        
+
         # Make the call
-        return self.__post_call(
-            endpoint = ENDPOINT,
-            json_data = json_data
-        )
+        return self.__post_call(endpoint=ENDPOINT, json_data=json_data)

--- a/pyxavi/firefish.py
+++ b/pyxavi/firefish.py
@@ -1,0 +1,160 @@
+import requests
+
+class Firefish:
+
+    bearer_token: str = None
+    api_base_url: str = None
+    client_name = None
+
+    
+    def create_app(self, client_name: str, api_base_url: str, to_file: str):
+        '''
+        Do we even need to register the app?
+        Not really, but this approach help us to define the API url and have it stored in a file.
+
+        So we emulate the behaviour in Mastodon.py:
+            - Create / Overwrite a file.
+            - Write the client_name
+            - Write the api_base_url
+        '''
+
+        # Clean the given API base URL before keeping it in mem.
+        if api_base_url[-1] == "/":
+            api_base_url = api_base_url[:-1]
+
+        # Write both. Order is important.
+        with open(to_file, 'w') as file:
+            file.write(api_base_url + "\n")
+            file.write(client_name + "\n")
+
+
+    def __init__(self, client_id: str = None, access_token: str = None):
+        '''
+        If client_id comes we expect to find a file called like client_id which contains the api_base_url.
+        If access_token comes we expect to find a file called like access_token which contains both api_base_url and the user token from login.
+
+        This is just to emulate the 2 step init that we have with Mastodon.py
+        '''
+
+        # So we received a client_id, this is actually a filename so read it and get the params.
+        if client_id is not None:
+            with open(client_id, 'r') as file:
+                self.api_base_url = file.readline()
+                self.client_name = file.readline()
+
+        # So we received an access_token, this is actually a filename so read it and get the params.
+        if client_id is not None:
+            with open(client_id, 'r') as file:
+                self.api_base_url = file.readline()
+                self.client_name = file.readline()
+                self.bearer_token = file.readline()
+
+
+    def log_in(self, username: str = None, password: str = None, to_file: str = None):
+        '''
+        I only need a Bearer token for authentication. Let's use "password" to receive it.
+        If the method is called, I assume that the class instatiaton was using the client_id, 
+            so we should have already the client_id params in memory.
+        If the to_file param is filled, we want to save the authentication into a file.
+        '''
+        if password is None:
+            raise RuntimeError("I need a Bearer token set into the 'password' param. Generate it and give it to me!")
+        
+        self.bearer_token = password
+
+        if to_file is not None:
+            with open(to_file, 'w') as file:
+                file.write(self.api_base_url + "\n")
+                file.write(self.client_name + "\n")
+                file.write(self.bearer_token + "\n")
+
+        
+        
+    
+    def __post_call(self, endpoint: str, headers: dict = {}, json: str = None):
+        response = requests.post(
+            url = f"{self.api_base_url}/{endpoint}",
+            headers={
+                **headers,
+                **{
+                    'Authorization': 'Bearer ' + self.bearer_token,
+                }
+            },
+            json=json
+        )
+
+        if response.status_code == 200:
+            return response.content
+        else:
+            raise RuntimeError(f"API Request ERROR -> {response.status_code}: {response.reason}")
+
+    def status_post(self, 
+                    status: str,
+                    in_reply_to_id=None,
+                    media_ids=None,
+                    sensitive=False,
+                    visibility=None,
+                    spoiler_text=None,
+                    language=None,
+                    idempotency_key=None,
+                    content_type=None,
+                    scheduled_at=None,
+                    poll=None,
+                    quote_id=None):
+        '''
+        Post a status. Can optionally be in reply to another status and contain media.
+
+        media_ids should be a list. (If it’s not, the function will turn it into one.) It can contain up to four pieces of media (uploaded via media_post()). media_ids can also be the `media dicts`_ returned by media_post() - they are unpacked automatically.
+
+        [not implemented] The sensitive boolean decides whether or not media attached to the post should be marked as sensitive, which hides it by default on the Mastodon web front-end.
+
+        The visibility parameter is a string value and accepts any of: ‘direct’ - post will be visible only to mentioned users ‘private’ - post will be visible only to followers ‘unlisted’ - post will be public but not appear on the public timeline ‘public’ - post will be public
+
+        If not passed in, visibility defaults to match the current account’s default-privacy setting (starting with Mastodon version 1.6) or its locked setting - private if the account is locked, public otherwise (for Mastodon versions lower than 1.6).
+
+        [not implemented] The spoiler_text parameter is a string to be shown as a warning before the text of the status. If no text is passed in, no warning will be displayed.
+
+        Specify language to override automatic language detection. The parameter accepts all valid ISO 639-1 (2-letter) or for languages where that do not have one, 639-3 (three letter) language codes.
+
+        [not implemented] You can set idempotency_key to a value to uniquely identify an attempt at posting a status. Even if you call this function more than once, if you call it with the same idempotency_key, only one status will be created.
+
+        [not implemented] Pass a datetime as scheduled_at to schedule the toot for a specific time (the time must be at least 5 minutes into the future). If this is passed, status_post returns a scheduled status dict instead.
+
+        [not implemented] Pass poll to attach a poll to the status. An appropriate object can be constructed using make_poll() . Note that as of Mastodon version 2.8.2, you can only have either media or a poll attached, not both at the same time.
+
+        [not implemented] Specific to “pleroma” feature set:: Specify content_type to set the content type of your post on Pleroma. It accepts ‘text/plain’ (default), ‘text/markdown’, ‘text/html’ and ‘text/bbcode’. This parameter is not supported on Mastodon servers, but will be safely ignored if set.
+
+        [not implemented] Specific to “fedibird” feature set:: The quote_id parameter is a non-standard extension that specifies the id of a quoted status.
+
+        [not implemented] Returns a status dict with the new status.
+
+        https://firefish.social/api-doc#operation/notes/create
+        '''
+        ENDPOINT = "api/notes/create"
+
+        # Text is mandatory
+        json_data = {
+            "text": status,
+        }
+
+        # Do we have files?
+        if media_ids is not None:
+            json_data["fileIds"] = media_ids
+
+        # Do we control visibility?
+        if visibility is not None:
+            json_data["visibility"] = visibility
+        
+        # Do we define the language?
+        if language is not None:
+            json_data["lang"] = language
+        
+        # Is this a reply to another status?
+        if in_reply_to_id is not None:
+            json_data["replyId"] = in_reply_to_id
+        
+        # Make the call
+        return self.__post_call(
+            endpoint = ENDPOINT,
+            json = json_data
+        )

--- a/pyxavi/firefish.py
+++ b/pyxavi/firefish.py
@@ -64,7 +64,7 @@ class Firefish:
             self.api_base_url = api_base_url
         
         # If we don't have a client_name, means that nothing came with. Error!
-        if self.client_name is None:
+        if self.client_name is None and self.api_base_url is None:
             raise RuntimeError("Mandatory params not found. Did you specify client_id or access_token?")
 
 

--- a/pyxavi/firefish.py
+++ b/pyxavi/firefish.py
@@ -11,7 +11,8 @@ class Firefish:
     def create_app(client_name: str, api_base_url: str, to_file: str):
         '''
         Do we even need to register the app?
-        Not really, but this approach help us to define the API url and have it stored in a file.
+        Not really, but this approach help us to define the API url and
+            have it stored in a file.
 
         So we emulate the behaviour in Mastodon.py:
             - Create / Overwrite a file.
@@ -20,8 +21,8 @@ class Firefish:
         '''
 
         if client_name is None or \
-            api_base_url is None or \
-            to_file is None:
+           api_base_url is None or \
+           to_file is None:
             raise RuntimeError("All params are mandatory")
 
         # Clean the given API base URL before keeping it in mem.
@@ -41,21 +42,25 @@ class Firefish:
         feature_set: str = None
     ):
         '''
-        If client_id comes we expect to find a file called like client_id which contains the api_base_url.
-        If access_token comes we expect to find a file called like access_token which contains both api_base_url and the user token from login.
+        If client_id comes we expect to find a file called like client_id
+            which contains the api_base_url.
+        If access_token comes we expect to find a file called like access_token
+            which contains both api_base_url and the user token from login.
         If api_base_url comes we just take it.
         We just ignore feature_set.
 
         This is just to emulate the 2 step init that we have with Mastodon.py
         '''
 
-        # So we received a client_id, this is actually a filename so read it and get the params.
+        # So we received a client_id,
+        # this is actually a filename so read it and get the params.
         if client_id is not None:
             with open(client_id, 'r') as file:
                 self.api_base_url = file.readline().strip()
                 self.client_name = file.readline().strip()
 
-        # So we received an access_token, this is actually a filename so read it and get the params.
+        # So we received an access_token,
+        # this is actually a filename so read it and get the params.
         if access_token is not None:
             with open(access_token, 'r') as file:
                 self.api_base_url = file.readline().strip()
@@ -74,13 +79,14 @@ class Firefish:
     def log_in(self, username: str = None, password: str = None, to_file: str = None):
         '''
         I only need a Bearer token for authentication. Let's use "password" to receive it.
-        If the method is called, I assume that the class instatiaton was using the client_id, 
+        If the method is called, I assume that the class instatiaton was using the client_id,
             so we should have already the client_id params in memory.
         If the to_file param is filled, we want to save the authentication into a file.
         '''
         if password is None:
             raise RuntimeError(
-                "I need a Bearer token set into the 'password' param. Generate it and give it to me!"
+                "I need a Bearer token set into the 'password' param." +
+                "Generate it and give it to me!"
             )
 
         self.bearer_token = password
@@ -128,31 +134,71 @@ class Firefish:
         quote_id=None
     ):
         '''
-        Post a status. Can optionally be in reply to another status and contain media.
+        Post a status. Can optionally be in reply to
+            another status and contain media.
 
-        media_ids should be a list. (If it’s not, the function will turn it into one.) It can contain up to four pieces of media (uploaded via media_post()). media_ids can also be the `media dicts`_ returned by media_post() - they are unpacked automatically.
+        media_ids should be a list. (If it’s not, the function
+            will turn it into one.) It can contain up to four
+            pieces of media (uploaded via media_post()).
+            media_ids can also be the `media dicts`_
+            returned by media_post() - they are unpacked
+            automatically.
 
-        [not implemented] The sensitive boolean decides whether or not media attached to the post should be marked as sensitive, which hides it by default on the Mastodon web front-end.
+        [to implement] The sensitive boolean decides whether
+            or not media attached to the post should be marked
+            as sensitive, which hides it by default on the
+            Mastodon web front-end.
 
-        The visibility parameter is a string value and accepts any of: ‘direct’ - post will be visible only to mentioned users ‘private’ - post will be visible only to followers ‘unlisted’ - post will be public but not appear on the public timeline ‘public’ - post will be public
+        The visibility parameter is a string value and
+            accepts any of: ‘direct’ - post will be visible
+            only to mentioned users ‘private’ - post will be
+            visible only to followers ‘unlisted’ - post will be
+            public but not appear on the public timeline
+            ‘public’ - post will be public
 
-        If not passed in, visibility defaults to match the current account’s default-privacy setting (starting with Mastodon version 1.6) or its locked setting - private if the account is locked, public otherwise (for Mastodon versions lower than 1.6).
+        If not passed in, visibility defaults to match the
+            current account’s default-privacy setting
+            (starting with Mastodon version 1.6) or its locked
+            setting - private if the account is locked,
+            public otherwise (for Mastodon versions lower than 1.6).
 
-        [not implemented] The spoiler_text parameter is a string to be shown as a warning before the text of the status. If no text is passed in, no warning will be displayed.
+        [to implement] The spoiler_text parameter is a string to be
+            shown as a warning before the text of the status.
+            If no text is passed in, no warning will be displayed.
 
-        Specify language to override automatic language detection. The parameter accepts all valid ISO 639-1 (2-letter) or for languages where that do not have one, 639-3 (three letter) language codes.
+        Specify language to override automatic language detection.
+            The parameter accepts all valid ISO 639-1 (2-letter)
+            or for languages where that do not have one,
+            639-3 (three letter) language codes.
 
-        [not implemented] You can set idempotency_key to a value to uniquely identify an attempt at posting a status. Even if you call this function more than once, if you call it with the same idempotency_key, only one status will be created.
+        [to implement] You can set idempotency_key to a value to
+            uniquely identify an attempt at posting a status.
+            Even if you call this function more than once,
+            if you call it with the same idempotency_key,
+            only one status will be created.
 
-        [not implemented] Pass a datetime as scheduled_at to schedule the toot for a specific time (the time must be at least 5 minutes into the future). If this is passed, status_post returns a scheduled status dict instead.
+        [to implement] Pass a datetime as scheduled_at to schedule
+            the toot for a specific time (the time must be
+            at least 5 minutes into the future). If this is passed,
+            status_post returns a scheduled status dict instead.
 
-        [not implemented] Pass poll to attach a poll to the status. An appropriate object can be constructed using make_poll() . Note that as of Mastodon version 2.8.2, you can only have either media or a poll attached, not both at the same time.
+        [to implement] Pass poll to attach a poll to the status.
+            An appropriate object can be constructed using make_poll().
+            Note that as of Mastodon version 2.8.2, you can only
+            have either media or a poll attached, not both at the same time.
 
-        [not implemented] Specific to “pleroma” feature set:: Specify content_type to set the content type of your post on Pleroma. It accepts ‘text/plain’ (default), ‘text/markdown’, ‘text/html’ and ‘text/bbcode’. This parameter is not supported on Mastodon servers, but will be safely ignored if set.
+        [to implement] Specific to “pleroma” feature set::
+            Specify content_type to set the content type of your
+            post on Pleroma. It accepts ‘text/plain’ (default),
+            ‘text/markdown’, ‘text/html’ and ‘text/bbcode’.
+            This parameter is not supported on Mastodon servers,
+            but will be safely ignored if set.
 
-        [not implemented] Specific to “fedibird” feature set:: The quote_id parameter is a non-standard extension that specifies the id of a quoted status.
+        [to implement] Specific to “fedibird” feature set::
+            The quote_id parameter is a non-standard extension
+            that specifies the id of a quoted status.
 
-        [not implemented] Returns a status dict with the new status.
+        [to implement] Returns a status dict with the new status.
 
         https://firefish.social/api-doc#operation/notes/create
         '''
@@ -174,7 +220,7 @@ class Firefish:
         if visibility is not None:
             # Translate the values from Mastodon to Firefish
             firefish_values_by_mastodon = {
-                "public": "public",  #"": "home",
+                "public": "public",  # "": "home",
                 "private": "followers",
                 "direct": "specified",
                 "unlisted": "hidden"

--- a/pyxavi/logger.py
+++ b/pyxavi/logger.py
@@ -48,4 +48,13 @@ class Logger:
         self._logger = logging.getLogger(config.get("logger.name", "custom_logger"))
 
     def getLogger(self) -> logging:
+        import warnings
+        warnings.warn(
+            "From v0.5.0 this method will disappear. Use get_logger() instead.",
+            DeprecationWarning,
+            stacklevel=2
+        )
+        return self._logger
+
+    def get_logger(self) -> logging:
         return self._logger

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -43,7 +43,7 @@ def test_initialize_config_with_another_filename():
 
 @patch("os.path.exists", new=os_path_exists_false)
 def test_initialize_config_file_not_found_exception():
-    with TestCase.assertRaises("bundle_basic.config", RuntimeError):
+    with TestCase.assertRaises("pyxavi.config", RuntimeError):
         _ = Config()
 
 

--- a/tests/test_firefish.py
+++ b/tests/test_firefish.py
@@ -40,3 +40,114 @@ def test_create_app(client_name, api_base_url, to_file, expected_values):
                 ]
             )
 
+def test_init_empty_fails():
+    with TestCase.assertRaises("pyxavi.firefish", RuntimeError):
+        _ = Firefish()
+
+def test_init_with_client_id():
+    client_id_filename = "client.secret"
+    client_id_client_name = "Client"
+    client_id_api_base_url = "https://social.devnamic.com"
+    client_id_content = f"{client_id_api_base_url}\n{client_id_client_name}"
+
+    mocked_open_file = MagicMock()
+    with patch.object(builtins, "open", mock_open(mock=mocked_open_file, read_data=client_id_content)):
+        instance = Firefish(client_id=client_id_filename)
+
+        mocked_open_file.assert_called_once_with(client_id_filename, "r")
+        assert instance.api_base_url == client_id_api_base_url
+        assert instance.client_name == client_id_client_name
+
+def test_init_with_client_id_and_api_base_url():
+    client_id_filename = "client.secret"
+    client_id_client_name = "Client"
+    client_id_api_base_url = "https://social.devnamic.com"
+    instance_api_base_url = "https://talamanca.social"
+    client_id_content = f"{client_id_api_base_url}\n{client_id_client_name}"
+
+    mocked_open_file = MagicMock()
+    with patch.object(builtins, "open", mock_open(mock=mocked_open_file, read_data=client_id_content)):
+        instance = Firefish(client_id=client_id_filename, api_base_url=instance_api_base_url)
+
+        mocked_open_file.assert_called_once_with(client_id_filename, "r")
+        assert instance.api_base_url == instance_api_base_url
+        assert instance.client_name == client_id_client_name
+
+
+def test_init_with_access_token():
+    access_token_filename = "user.secret"
+    access_token_client_name = "Client"
+    access_token_api_base_url = "https://social.devnamic.com"
+    access_token_token = "abcdefg123456"
+    access_token_content = f"{access_token_api_base_url}\n{access_token_client_name}\n{access_token_token}"
+
+    mocked_open_file = MagicMock()
+    with patch.object(builtins, "open", mock_open(mock=mocked_open_file, read_data=access_token_content)):
+        instance = Firefish(access_token=access_token_filename)
+
+        mocked_open_file.assert_called_once_with(access_token_filename, "r")
+        assert instance.api_base_url == access_token_api_base_url
+        assert instance.client_name == access_token_client_name
+        assert instance.bearer_token == access_token_token
+
+def test_init_with_access_token_with_api_base_url():
+    access_token_filename = "user.secret"
+    access_token_client_name = "Client"
+    access_token_api_base_url = "https://social.devnamic.com"
+    instance_api_base_url = "https://talamanca.social"
+    access_token_token = "abcdefg123456"
+    access_token_content = f"{access_token_api_base_url}\n{access_token_client_name}\n{access_token_token}"
+
+    mocked_open_file = MagicMock()
+    with patch.object(builtins, "open", mock_open(mock=mocked_open_file, read_data=access_token_content)):
+        instance = Firefish(access_token=access_token_filename, api_base_url=instance_api_base_url)
+
+        mocked_open_file.assert_called_once_with(access_token_filename, "r")
+        assert instance.api_base_url == instance_api_base_url
+        assert instance.client_name == access_token_client_name
+        assert instance.bearer_token == access_token_token
+
+
+def test_log_in_without_password():
+    client_id_filename = "client.secret"
+    client_id_client_name = "Client"
+    client_id_api_base_url = "https://social.devnamic.com"
+    client_id_content = f"{client_id_api_base_url}\n{client_id_client_name}"
+
+    mocked_open_file = MagicMock()
+    with patch.object(builtins, "open", mock_open(mock=mocked_open_file, read_data=client_id_content)):
+        instance = Firefish(client_id=client_id_filename)
+        with TestCase.assertRaises(instance, RuntimeError):
+            instance.log_in(username="test")
+
+def test_log_in_with_password():
+    client_id_filename = "client.secret"
+    client_id_client_name = "Client"
+    client_id_api_base_url = "https://social.devnamic.com"
+    client_id_content = f"{client_id_api_base_url}\n{client_id_client_name}"
+    token = "abcdefg123456"
+    access_token_filename = "user.secret"
+    access_token_filename = "user.secret"
+    access_token_client_name = "Client"
+    access_token_api_base_url = "https://social.devnamic.com"
+
+    
+    with patch.object(builtins, "open", mock_open(read_data=client_id_content)):
+        instance = Firefish(client_id=client_id_filename)
+
+    mocked_open_file = MagicMock()
+    with patch.object(builtins, "open", mock_open(mock=mocked_open_file)):
+        instance.log_in(username="test",
+                        password=token,
+                        to_file=access_token_filename)
+
+        handle = mocked_open_file()
+        handle.write.assert_has_calls(
+            [
+                call(access_token_api_base_url + "\n"),
+                call(access_token_client_name + "\n"),
+                call(token)
+            ]
+        )
+
+        assert instance.bearer_token == token

--- a/tests/test_firefish.py
+++ b/tests/test_firefish.py
@@ -1,0 +1,102 @@
+from pyxavi.janitor import Janitor
+from unittest.mock import Mock, patch
+import pytest
+import requests
+import socket
+
+def test_create_app_missing_parameters():
+    pass
+
+def test_create_app_file_is_created():
+    pass
+
+def test_create_app_file_already_was_there_success():
+    pass
+
+def test_create_app_file_already_was_there_failed():
+    pass
+
+def test_initialize_with_hostname():
+    remote_url = "https://i.am.an.url:5000"
+    hostname_param = "endor"
+    hostname_socket = "alderaan"
+
+    mocked_socket_gethostname = Mock()
+    mocked_socket_gethostname.return_value = hostname_socket
+
+    with patch.object(socket, "gethostname", new=mocked_socket_gethostname):
+        instance = Janitor(remote_url=remote_url, hostname=hostname_param)
+
+    mocked_socket_gethostname.assert_not_called()
+    assert isinstance(instance, Janitor) is True
+    assert instance._remote_url == remote_url
+    assert instance._hostname == hostname_param
+
+
+def test_initialize_without_hostname():
+    remote_url = "https://i.am.an.url:5000"
+    hostname_socket = "alderaan"
+
+    mocked_socket_gethostname = Mock()
+    mocked_socket_gethostname.return_value = hostname_socket
+
+    with patch.object(socket, "gethostname", new=mocked_socket_gethostname):
+        instance = Janitor(remote_url=remote_url)
+
+    mocked_socket_gethostname.assert_called_once()
+    assert isinstance(instance, Janitor) is True
+    assert instance._remote_url == remote_url
+    assert instance._hostname == hostname_socket
+
+
+@pytest.mark.parametrize(
+    argnames=('call', 'message_type', 'message', 'summary', 'expected_result'),
+    argvalues=[
+        ("log", Janitor.MessageType.NONE, "I am a message", None, 200),
+        ("log", Janitor.MessageType.NONE, "I am a message", "I am a summary", 200),
+        ("info", Janitor.MessageType.INFO, "I am a message", None, 200),
+        ("info", Janitor.MessageType.INFO, "I am a message", "I am a summary", 200),
+        ("warning", Janitor.MessageType.WARNING, "I am a message", None, 200),
+        ("warning", Janitor.MessageType.WARNING, "I am a message", "I am a summary", 200),
+        ("error", Janitor.MessageType.ERROR, "I am a message", None, 200),
+        ("error", Janitor.MessageType.ERROR, "I am a message", "I am a summary", 200),
+        ("alarm", Janitor.MessageType.ALARM, "I am a message", None, 200),
+        ("alarm", Janitor.MessageType.ALARM, "I am a message", "I am a summary", 200),
+    ],
+)
+def test_messaging(call, message_type, message, summary, expected_result):
+
+    class ObjectFaker:
+
+        def __init__(self, d: dict):
+            for key, value in d.items():
+                setattr(self, key, value)
+
+    hostname = "hostname"
+    remote_url = "https://i.am.an.url:5000"
+
+    expected_params = {
+        "hostname": hostname, "message": message, "message_type": str(message_type)
+    }
+    if summary is not None:
+        expected_params["summary"] = summary
+
+    mocked_requests_post = Mock()
+    mocked_requests_post.return_value = ObjectFaker({"status_code": expected_result})
+
+    instance = Janitor(remote_url=remote_url, hostname=hostname)
+
+    with patch.object(requests, "post", new=mocked_requests_post):
+        if call == "log":
+            result = instance.log(message=message, summary=summary)
+        elif call == "info":
+            result = instance.info(message=message, summary=summary)
+        elif call == "warning":
+            result = instance.warning(message=message, summary=summary)
+        elif call == "error":
+            result = instance.error(message=message, summary=summary)
+        elif call == "alarm":
+            result = instance.alarm(message=message, summary=summary)
+
+    assert result == expected_result
+    mocked_requests_post.assert_called_once_with(f"{remote_url}/message", data=expected_params)

--- a/tests/test_firefish.py
+++ b/tests/test_firefish.py
@@ -1,102 +1,42 @@
-from pyxavi.janitor import Janitor
-from unittest.mock import Mock, patch
+from pyxavi.firefish import Firefish
+from unittest.mock import Mock, patch, mock_open, call, MagicMock
+from unittest import TestCase
 import pytest
+import builtins
 import requests
 import socket
 
-def test_create_app_missing_parameters():
-    pass
-
-def test_create_app_file_is_created():
-    pass
-
-def test_create_app_file_already_was_there_success():
-    pass
-
-def test_create_app_file_already_was_there_failed():
-    pass
-
-def test_initialize_with_hostname():
-    remote_url = "https://i.am.an.url:5000"
-    hostname_param = "endor"
-    hostname_socket = "alderaan"
-
-    mocked_socket_gethostname = Mock()
-    mocked_socket_gethostname.return_value = hostname_socket
-
-    with patch.object(socket, "gethostname", new=mocked_socket_gethostname):
-        instance = Janitor(remote_url=remote_url, hostname=hostname_param)
-
-    mocked_socket_gethostname.assert_not_called()
-    assert isinstance(instance, Janitor) is True
-    assert instance._remote_url == remote_url
-    assert instance._hostname == hostname_param
-
-
-def test_initialize_without_hostname():
-    remote_url = "https://i.am.an.url:5000"
-    hostname_socket = "alderaan"
-
-    mocked_socket_gethostname = Mock()
-    mocked_socket_gethostname.return_value = hostname_socket
-
-    with patch.object(socket, "gethostname", new=mocked_socket_gethostname):
-        instance = Janitor(remote_url=remote_url)
-
-    mocked_socket_gethostname.assert_called_once()
-    assert isinstance(instance, Janitor) is True
-    assert instance._remote_url == remote_url
-    assert instance._hostname == hostname_socket
-
-
 @pytest.mark.parametrize(
-    argnames=('call', 'message_type', 'message', 'summary', 'expected_result'),
+    argnames=('client_name', 'api_base_url', 'to_file', 'expected_values'),
     argvalues=[
-        ("log", Janitor.MessageType.NONE, "I am a message", None, 200),
-        ("log", Janitor.MessageType.NONE, "I am a message", "I am a summary", 200),
-        ("info", Janitor.MessageType.INFO, "I am a message", None, 200),
-        ("info", Janitor.MessageType.INFO, "I am a message", "I am a summary", 200),
-        ("warning", Janitor.MessageType.WARNING, "I am a message", None, 200),
-        ("warning", Janitor.MessageType.WARNING, "I am a message", "I am a summary", 200),
-        ("error", Janitor.MessageType.ERROR, "I am a message", None, 200),
-        ("error", Janitor.MessageType.ERROR, "I am a message", "I am a summary", 200),
-        ("alarm", Janitor.MessageType.ALARM, "I am a message", None, 200),
-        ("alarm", Janitor.MessageType.ALARM, "I am a message", "I am a summary", 200),
+        (None, None, None, False),
+        ("Client", "https://social.devnamic.com", None, False),
+        ("Client", None, "client.secret", False),
+        (None, "https://social.devnamic.com", "client.secret", False),
+        ("Client", "https://social.devnamic.com", "client.secret", ("Client", "https://social.devnamic.com")),
+        ("Client", "https://social.devnamic.com/", "client.secret", ("Client", "https://social.devnamic.com"))
     ],
 )
-def test_messaging(call, message_type, message, summary, expected_result):
+def test_create_app(client_name, api_base_url, to_file, expected_values):
 
-    class ObjectFaker:
+    if expected_values is False:
+        with TestCase.assertRaises("pyxavi.firefish", RuntimeError):
+            Firefish.create_app(client_name=client_name,
+                            api_base_url=api_base_url,
+                            to_file=to_file)
+    else:
+        expected_client_name, expected_api_base_url = expected_values
+        mocked_open_file = MagicMock()
+        with patch.object(builtins, "open", mock_open(mock=mocked_open_file)):
+            Firefish.create_app(client_name=client_name,
+                            api_base_url=api_base_url,
+                            to_file=to_file)
+            
+            handle = mocked_open_file()
+            handle.write.assert_has_calls(
+                [
+                    call(expected_api_base_url + "\n"),
+                    call(expected_client_name)
+                ]
+            )
 
-        def __init__(self, d: dict):
-            for key, value in d.items():
-                setattr(self, key, value)
-
-    hostname = "hostname"
-    remote_url = "https://i.am.an.url:5000"
-
-    expected_params = {
-        "hostname": hostname, "message": message, "message_type": str(message_type)
-    }
-    if summary is not None:
-        expected_params["summary"] = summary
-
-    mocked_requests_post = Mock()
-    mocked_requests_post.return_value = ObjectFaker({"status_code": expected_result})
-
-    instance = Janitor(remote_url=remote_url, hostname=hostname)
-
-    with patch.object(requests, "post", new=mocked_requests_post):
-        if call == "log":
-            result = instance.log(message=message, summary=summary)
-        elif call == "info":
-            result = instance.info(message=message, summary=summary)
-        elif call == "warning":
-            result = instance.warning(message=message, summary=summary)
-        elif call == "error":
-            result = instance.error(message=message, summary=summary)
-        elif call == "alarm":
-            result = instance.alarm(message=message, summary=summary)
-
-    assert result == expected_result
-    mocked_requests_post.assert_called_once_with(f"{remote_url}/message", data=expected_params)

--- a/tests/test_firefish.py
+++ b/tests/test_firefish.py
@@ -6,43 +6,50 @@ import builtins
 import requests
 import socket
 
+
 @pytest.mark.parametrize(
     argnames=('client_name', 'api_base_url', 'to_file', 'expected_values'),
     argvalues=[
-        (None, None, None, False),
-        ("Client", "https://social.devnamic.com", None, False),
+        (None, None, None, False), ("Client", "https://social.devnamic.com", None, False),
         ("Client", None, "client.secret", False),
         (None, "https://social.devnamic.com", "client.secret", False),
-        ("Client", "https://social.devnamic.com", "client.secret", ("Client", "https://social.devnamic.com")),
-        ("Client", "https://social.devnamic.com/", "client.secret", ("Client", "https://social.devnamic.com"))
+        (
+            "Client",
+            "https://social.devnamic.com",
+            "client.secret", ("Client", "https://social.devnamic.com")
+        ),
+        (
+            "Client",
+            "https://social.devnamic.com/",
+            "client.secret", ("Client", "https://social.devnamic.com")
+        )
     ],
 )
 def test_create_app(client_name, api_base_url, to_file, expected_values):
 
     if expected_values is False:
         with TestCase.assertRaises("pyxavi.firefish", RuntimeError):
-            Firefish.create_app(client_name=client_name,
-                            api_base_url=api_base_url,
-                            to_file=to_file)
+            Firefish.create_app(
+                client_name=client_name, api_base_url=api_base_url, to_file=to_file
+            )
     else:
         expected_client_name, expected_api_base_url = expected_values
         mocked_open_file = MagicMock()
         with patch.object(builtins, "open", mock_open(mock=mocked_open_file)):
-            Firefish.create_app(client_name=client_name,
-                            api_base_url=api_base_url,
-                            to_file=to_file)
-            
+            Firefish.create_app(
+                client_name=client_name, api_base_url=api_base_url, to_file=to_file
+            )
+
             handle = mocked_open_file()
             handle.write.assert_has_calls(
-                [
-                    call(expected_api_base_url + "\n"),
-                    call(expected_client_name)
-                ]
+                [call(expected_api_base_url + "\n"), call(expected_client_name)]
             )
+
 
 def test_init_empty_fails():
     with TestCase.assertRaises("pyxavi.firefish", RuntimeError):
         _ = Firefish()
+
 
 def test_init_with_client_id():
     client_id_filename = "client.secret"
@@ -51,12 +58,15 @@ def test_init_with_client_id():
     client_id_content = f"{client_id_api_base_url}\n{client_id_client_name}"
 
     mocked_open_file = MagicMock()
-    with patch.object(builtins, "open", mock_open(mock=mocked_open_file, read_data=client_id_content)):
+    with patch.object(builtins,
+                      "open",
+                      mock_open(mock=mocked_open_file, read_data=client_id_content)):
         instance = Firefish(client_id=client_id_filename)
 
         mocked_open_file.assert_called_once_with(client_id_filename, "r")
         assert instance.api_base_url == client_id_api_base_url
         assert instance.client_name == client_id_client_name
+
 
 def test_init_with_client_id_and_api_base_url():
     client_id_filename = "client.secret"
@@ -66,7 +76,9 @@ def test_init_with_client_id_and_api_base_url():
     client_id_content = f"{client_id_api_base_url}\n{client_id_client_name}"
 
     mocked_open_file = MagicMock()
-    with patch.object(builtins, "open", mock_open(mock=mocked_open_file, read_data=client_id_content)):
+    with patch.object(builtins,
+                      "open",
+                      mock_open(mock=mocked_open_file, read_data=client_id_content)):
         instance = Firefish(client_id=client_id_filename, api_base_url=instance_api_base_url)
 
         mocked_open_file.assert_called_once_with(client_id_filename, "r")
@@ -82,13 +94,16 @@ def test_init_with_access_token():
     access_token_content = f"{access_token_api_base_url}\n{access_token_client_name}\n{access_token_token}"
 
     mocked_open_file = MagicMock()
-    with patch.object(builtins, "open", mock_open(mock=mocked_open_file, read_data=access_token_content)):
+    with patch.object(builtins,
+                      "open",
+                      mock_open(mock=mocked_open_file, read_data=access_token_content)):
         instance = Firefish(access_token=access_token_filename)
 
         mocked_open_file.assert_called_once_with(access_token_filename, "r")
         assert instance.api_base_url == access_token_api_base_url
         assert instance.client_name == access_token_client_name
         assert instance.bearer_token == access_token_token
+
 
 def test_init_with_access_token_with_api_base_url():
     access_token_filename = "user.secret"
@@ -99,8 +114,12 @@ def test_init_with_access_token_with_api_base_url():
     access_token_content = f"{access_token_api_base_url}\n{access_token_client_name}\n{access_token_token}"
 
     mocked_open_file = MagicMock()
-    with patch.object(builtins, "open", mock_open(mock=mocked_open_file, read_data=access_token_content)):
-        instance = Firefish(access_token=access_token_filename, api_base_url=instance_api_base_url)
+    with patch.object(builtins,
+                      "open",
+                      mock_open(mock=mocked_open_file, read_data=access_token_content)):
+        instance = Firefish(
+            access_token=access_token_filename, api_base_url=instance_api_base_url
+        )
 
         mocked_open_file.assert_called_once_with(access_token_filename, "r")
         assert instance.api_base_url == instance_api_base_url
@@ -115,10 +134,13 @@ def test_log_in_without_password():
     client_id_content = f"{client_id_api_base_url}\n{client_id_client_name}"
 
     mocked_open_file = MagicMock()
-    with patch.object(builtins, "open", mock_open(mock=mocked_open_file, read_data=client_id_content)):
+    with patch.object(builtins,
+                      "open",
+                      mock_open(mock=mocked_open_file, read_data=client_id_content)):
         instance = Firefish(client_id=client_id_filename)
         with TestCase.assertRaises(instance, RuntimeError):
             instance.log_in(username="test")
+
 
 def test_log_in_with_password():
     client_id_filename = "client.secret"
@@ -131,15 +153,12 @@ def test_log_in_with_password():
     access_token_client_name = "Client"
     access_token_api_base_url = "https://social.devnamic.com"
 
-    
     with patch.object(builtins, "open", mock_open(read_data=client_id_content)):
         instance = Firefish(client_id=client_id_filename)
 
     mocked_open_file = MagicMock()
     with patch.object(builtins, "open", mock_open(mock=mocked_open_file)):
-        instance.log_in(username="test",
-                        password=token,
-                        to_file=access_token_filename)
+        instance.log_in(username="test", password=token, to_file=access_token_filename)
 
         handle = mocked_open_file()
         handle.write.assert_has_calls(
@@ -152,14 +171,28 @@ def test_log_in_with_password():
 
         assert instance.bearer_token == token
 
+
 @pytest.mark.parametrize(
-    argnames=('endpoint', 'headers', 'json_data', 'expected_status_code', 'expected_content', 'expected_reason'),
+    argnames=(
+        'endpoint',
+        'headers',
+        'json_data',
+        'expected_status_code',
+        'expected_content',
+        'expected_reason'
+    ),
     argvalues=[
-        ("/api/notes/create", {}, {"text": "test"}, 200, "OK", None),
-        ("/api/notes/create", {}, {"text": "test"}, 401, None, "Unauthortised")
+        ("/api/notes/create", {}, {
+            "text": "test"
+        }, 200, "OK", None),
+        ("/api/notes/create", {}, {
+            "text": "test"
+        }, 401, None, "Unauthortised")
     ],
 )
-def test__post_call(endpoint, headers, json_data, expected_status_code, expected_content, expected_reason):
+def test__post_call(
+    endpoint, headers, json_data, expected_status_code, expected_content, expected_reason
+):
     access_token_filename = "user.secret"
     access_token_client_name = "Client"
     access_token_api_base_url = "https://social.devnamic.com"
@@ -174,58 +207,201 @@ def test__post_call(endpoint, headers, json_data, expected_status_code, expected
         content: str
         reason: str
 
-        def __init__(self,
-                     status_code: int,
-                     content: str = None,
-                     reason: str = None) -> None:
+        def __init__(self, status_code: int, content: str = None, reason: str = None) -> None:
             self.status_code = status_code
             self.content = content
             self.reason = reason
 
     mocked_requests_post = Mock()
-    mocked_requests_post.return_value = Response(status_code=expected_status_code,
-                                                 content=expected_content,
-                                                 reason=expected_reason)
+    mocked_requests_post.return_value = Response(
+        status_code=expected_status_code, content=expected_content, reason=expected_reason
+    )
     with patch.object(requests, "post", new=mocked_requests_post):
         if expected_status_code == 200:
-            returned_content = instance._Firefish__post_call(endpoint=endpoint,
-                                                    headers=headers,
-                                                    json_data=json_data)
+            returned_content = instance._Firefish__post_call(
+                endpoint=endpoint, headers=headers, json_data=json_data
+            )
             assert returned_content == expected_content
         else:
             with TestCase.assertRaises(instance, RuntimeError):
-                instance._Firefish__post_call(endpoint=endpoint,
-                                headers=headers,
-                                json_data=json_data)
+                instance._Firefish__post_call(
+                    endpoint=endpoint, headers=headers, json_data=json_data
+                )
+
 
 @pytest.mark.parametrize(
-    argnames=('status', 'in_reply_to_id', 'media_ids', 'sensitive', 'visibility', 'spoiler_text', 'language', 'idempotency_key', 'content_type', 'scheduled_at', 'poll', 'quote_id', 'expected_endpoint', 'expected_json'),
+    argnames=(
+        'status',
+        'in_reply_to_id',
+        'media_ids',
+        'sensitive',
+        'visibility',
+        'spoiler_text',
+        'language',
+        'idempotency_key',
+        'content_type',
+        'scheduled_at',
+        'poll',
+        'quote_id',
+        'expected_endpoint',
+        'expected_json'
+    ),
     argvalues=[
         (None, None, None, None, None, None, None, None, None, None, None, None, None, None),
-        ("test content", None, None, None, None, None, None, None, None, None, None, None, "api/notes/create", {"text": "test content"}),
-        ("test content", None, [123], None, None, None, None, None, None, None, None, None, "api/notes/create", {"text": "test content", "fileIds": [123]}),
-        ("test content", None, None, None, "public", None, None, None, None, None, None, None, "api/notes/create", {"text": "test content", "visibility": "public"}),
-        ("test content", None, None, None, "private", None, None, None, None, None, None, None, "api/notes/create", {"text": "test content", "visibility": "followers"}),
-        ("test content", None, None, None, "direct", None, None, None, None, None, None, None, "api/notes/create", {"text": "test content", "visibility": "specified"}),
-        ("test content", None, None, None, "unlisted", None, None, None, None, None, None, None, "api/notes/create", {"text": "test content", "visibility": "hidden"}),
-        ("test content", None, None, None, None, None, "ca", None, None, None, None, None, "api/notes/create", {"text": "test content", "lang": "ca"}),
-        ("test content", 1234, None, None, None, None, None, None, None, None, None, None, "api/notes/create", {"text": "test content", "replyId": 1234}),
+        (
+            "test content",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            "api/notes/create", {
+                "text": "test content"
+            }
+        ),
+        (
+            "test content",
+            None, [123],
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            "api/notes/create", {
+                "text": "test content", "fileIds": [123]
+            }
+        ),
+        (
+            "test content",
+            None,
+            None,
+            None,
+            "public",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            "api/notes/create", {
+                "text": "test content", "visibility": "public"
+            }
+        ),
+        (
+            "test content",
+            None,
+            None,
+            None,
+            "private",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            "api/notes/create", {
+                "text": "test content", "visibility": "followers"
+            }
+        ),
+        (
+            "test content",
+            None,
+            None,
+            None,
+            "direct",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            "api/notes/create", {
+                "text": "test content", "visibility": "specified"
+            }
+        ),
+        (
+            "test content",
+            None,
+            None,
+            None,
+            "unlisted",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            "api/notes/create", {
+                "text": "test content", "visibility": "hidden"
+            }
+        ),
+        (
+            "test content",
+            None,
+            None,
+            None,
+            None,
+            None,
+            "ca",
+            None,
+            None,
+            None,
+            None,
+            None,
+            "api/notes/create", {
+                "text": "test content", "lang": "ca"
+            }
+        ),
+        (
+            "test content",
+            1234,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            "api/notes/create", {
+                "text": "test content", "replyId": 1234
+            }
+        ),
     ],
 )
-def test_status_post(status,
-                    in_reply_to_id,
-                    media_ids,
-                    sensitive,
-                    visibility,
-                    spoiler_text,
-                    language,
-                    idempotency_key,
-                    content_type,
-                    scheduled_at,
-                    poll,
-                    quote_id,
-                    expected_endpoint,
-                    expected_json):
+def test_status_post(
+    status,
+    in_reply_to_id,
+    media_ids,
+    sensitive,
+    visibility,
+    spoiler_text,
+    language,
+    idempotency_key,
+    content_type,
+    scheduled_at,
+    poll,
+    quote_id,
+    expected_endpoint,
+    expected_json
+):
+
     access_token_filename = "user.secret"
     access_token_client_name = "Client"
     access_token_api_base_url = "https://social.devnamic.com"
@@ -270,6 +446,5 @@ def test_status_post(status,
             )
 
             mocked_post_call.assert_called_once_with(
-                endpoint = expected_endpoint,
-                json_data = expected_json
+                endpoint=expected_endpoint, json_data=expected_json
             )

--- a/tests/test_firefish.py
+++ b/tests/test_firefish.py
@@ -4,7 +4,6 @@ from unittest import TestCase
 import pytest
 import builtins
 import requests
-import socket
 
 
 @pytest.mark.parametrize(
@@ -55,7 +54,7 @@ def test_init_with_client_id():
     client_id_filename = "client.secret"
     client_id_client_name = "Client"
     client_id_api_base_url = "https://social.devnamic.com"
-    client_id_content = f"{client_id_api_base_url}\n{client_id_client_name}"
+    client_id_content = "\n".join([client_id_api_base_url, client_id_client_name])
 
     mocked_open_file = MagicMock()
     with patch.object(builtins,
@@ -73,7 +72,7 @@ def test_init_with_client_id_and_api_base_url():
     client_id_client_name = "Client"
     client_id_api_base_url = "https://social.devnamic.com"
     instance_api_base_url = "https://talamanca.social"
-    client_id_content = f"{client_id_api_base_url}\n{client_id_client_name}"
+    client_id_content = "\n".join([client_id_api_base_url, client_id_client_name])
 
     mocked_open_file = MagicMock()
     with patch.object(builtins,
@@ -91,7 +90,9 @@ def test_init_with_access_token():
     access_token_client_name = "Client"
     access_token_api_base_url = "https://social.devnamic.com"
     access_token_token = "abcdefg123456"
-    access_token_content = f"{access_token_api_base_url}\n{access_token_client_name}\n{access_token_token}"
+    access_token_content = "\n".join(
+        [access_token_api_base_url, access_token_client_name, access_token_token]
+    )
 
     mocked_open_file = MagicMock()
     with patch.object(builtins,
@@ -111,7 +112,9 @@ def test_init_with_access_token_with_api_base_url():
     access_token_api_base_url = "https://social.devnamic.com"
     instance_api_base_url = "https://talamanca.social"
     access_token_token = "abcdefg123456"
-    access_token_content = f"{access_token_api_base_url}\n{access_token_client_name}\n{access_token_token}"
+    access_token_content = "\n".join(
+        [access_token_api_base_url, access_token_client_name, access_token_token]
+    )
 
     mocked_open_file = MagicMock()
     with patch.object(builtins,
@@ -131,7 +134,7 @@ def test_log_in_without_password():
     client_id_filename = "client.secret"
     client_id_client_name = "Client"
     client_id_api_base_url = "https://social.devnamic.com"
-    client_id_content = f"{client_id_api_base_url}\n{client_id_client_name}"
+    client_id_content = "\n".join([client_id_api_base_url, client_id_client_name])
 
     mocked_open_file = MagicMock()
     with patch.object(builtins,
@@ -146,7 +149,7 @@ def test_log_in_with_password():
     client_id_filename = "client.secret"
     client_id_client_name = "Client"
     client_id_api_base_url = "https://social.devnamic.com"
-    client_id_content = f"{client_id_api_base_url}\n{client_id_client_name}"
+    client_id_content = "\n".join([client_id_api_base_url, client_id_client_name])
     token = "abcdefg123456"
     access_token_filename = "user.secret"
     access_token_filename = "user.secret"
@@ -197,7 +200,9 @@ def test__post_call(
     access_token_client_name = "Client"
     access_token_api_base_url = "https://social.devnamic.com"
     access_token_token = "abcdefg123456"
-    access_token_content = f"{access_token_api_base_url}\n{access_token_client_name}\n{access_token_token}"
+    access_token_content = "\n".join(
+        [access_token_api_base_url, access_token_client_name, access_token_token]
+    )
 
     with patch.object(builtins, "open", mock_open(read_data=access_token_content)):
         instance = Firefish(access_token=access_token_filename)
@@ -406,7 +411,9 @@ def test_status_post(
     access_token_client_name = "Client"
     access_token_api_base_url = "https://social.devnamic.com"
     access_token_token = "abcdefg123456"
-    access_token_content = f"{access_token_api_base_url}\n{access_token_client_name}\n{access_token_token}"
+    access_token_content = "\n".join(
+        [access_token_api_base_url, access_token_client_name, access_token_token]
+    )
 
     with patch.object(builtins, "open", mock_open(read_data=access_token_content)):
         instance = Firefish(access_token=access_token_filename)

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -27,7 +27,7 @@ def test_initialize_logger():
 
     config = Config()
 
-    new_instance = Logger(config).getLogger()
+    new_instance = Logger(config).get_logger()
 
     from_logging = logging.getLogger(CONFIG["logger.name"])
 


### PR DESCRIPTION
At this point, only needed:

- Authentication
- Publish a Post

Nice to have:

- Bring the Mastodon Helper into the library
- Empty NEXT_MAJOR requests