### PR TITLE
Ensure that the filename is present when prepating the path

### DIFF
--- a/pyxavi/logger.py
+++ b/pyxavi/logger.py
@@ -201,7 +201,7 @@ class Logger:
     def _load_old_config_without_defaults(self, config: Config) -> Dictionary:
         # Previous work
         filename = config.get("logger.filename")
-        if self._base_path is not None:
+        if self._base_path is not None and filename is not None:
             filename = os.path.join(self._base_path, filename)
 
         # What we do here is to build a main dict where we ensure we always have a value.
@@ -225,7 +225,7 @@ class Logger:
     def _load_new_config_without_defaults(self, config: Config) -> Dictionary:
         # Previous work
         filename = config.get("logger.file.filename")
-        if self._base_path is not None:
+        if self._base_path is not None and filename is not None:
             filename = os.path.join(self._base_path, filename)
 
         # What we do here is to build a main dict where we ensure we always have a value.


### PR DESCRIPTION
In the Logger, when reading the filename from the config, we join it with the base_path if not None. The filename may not come with either.