### PR TITLE
Add slugify() support into param parts for Dictionary

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,6 @@
+## Description of feature / issue
+
+
+## What was done
+
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [v1.3.0](https://github.com/XaviArnaus/pyxavi/releases/tag/v1.3.0) - 2025-12-05
+
+### Added
+
+- Added slugified keys support in Dictionary ([#55](https://github.com/XaviArnaus/pyxavi/pull/55)).
+
+### Fixed
+
+- Fixed `set()` not creating defined missing keys ([#55](https://github.com/XaviArnaus/pyxavi/pull/55))
+
 ## [v1.2.0](https://github.com/XaviArnaus/pyxavi/releases/tag/v1.2.0) - 2025-11-13
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added slugified keys support in Dictionary ([#55](https://github.com/XaviArnaus/pyxavi/pull/55)).
+- Added a pull request template ([#55](https://github.com/XaviArnaus/pyxavi/pull/55)).
 
 ### Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyxavi"
-version = "1.2.0"
+version = "1.3.0"
 description = "Set of utilities to assist on simple Python projects"
 authors = ["Xavier Arnaus <xavi@arnaus.net>"]
 readme = "README.md"

--- a/pyxavi/dictionary.py
+++ b/pyxavi/dictionary.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 from slugify import slugify
 import copy
 
-from pyxavi.debugger import dd
-
 PATH_SEPARATOR_CHAR = "."
 LIST_HORIZONTAL_RESOLVING_CHAR = "#"
 
@@ -50,7 +48,9 @@ class Dictionary:
             return element[1:].isdecimal()
         return element.isdecimal()
 
-    def get(self, param_name: str = "", default_value: any = None, slugify_param_name=False) -> any:
+    def get(
+        self, param_name: str = "", default_value: any = None, slugify_param_name=False
+    ) -> any:
         """
         Returns the value found in the given param_name path,
         otherwise default_value is returned
@@ -139,7 +139,7 @@ class Dictionary:
                     )
             elif isinstance(dictionary, dict):
                 # The dictionary argument is a dict
-                
+
                 # Now, the key may not exists.
                 if pieces[0] not in dictionary:
                     # This is a set(), if the key doesn't exist, we create it as an empty dict
@@ -205,7 +205,7 @@ class Dictionary:
         """
         if param_name is None:
             raise RuntimeError("Params must have a name")
-        
+
         param_name = self._slugify_param_name_if_needed(param_name, slugify_param_name)
 
         if Dictionary.needs_resolving(param_name=param_name):
@@ -242,7 +242,7 @@ class Dictionary:
         Returns the last key of the param_name
         """
         param_name = self._slugify_param_name_if_needed(param_name, slugify_param_name)
-        
+
         return param_name.split(self._separator)[-1]\
             if param_name.find(self._separator) > 0 else param_name
 
@@ -343,7 +343,9 @@ class Dictionary:
         """Shortcut to get_all()"""
         return self.get_all()
 
-    def merge(self, origin: Dictionary, param_name: str = None, slugify_param_name=False) -> None:
+    def merge(
+        self, origin: Dictionary, param_name: str = None, slugify_param_name=False
+    ) -> None:
         """
         Takes a given Dictionary object and merges it into the current object
             as the given param_name (or at root if None given)
@@ -527,8 +529,10 @@ class Dictionary:
             returning_stack.append(self.get_parent(param_name=path))
 
         return returning_stack
-    
-    def _slugify_param_name_if_needed(self, param_name: str, slugify_param_name: bool = False) -> str:
+
+    def _slugify_param_name_if_needed(
+        self, param_name: str, slugify_param_name: bool = False
+    ) -> str:
         """
         Slugifies all the parts from the parameter name.
 
@@ -537,10 +541,12 @@ class Dictionary:
         """
         if not slugify_param_name:
             return param_name
-        
+
         if not Dictionary.needs_resolving(param_name):
-            return self._separator.join([slugify(part) for part in param_name.split(self._separator)])
-        
+            return self._separator.join(
+                [slugify(part) for part in param_name.split(self._separator)]
+            )
+
         # We have horizontal resolving chars, so we need to respect them
         portions = param_name.split(LIST_HORIZONTAL_RESOLVING_CHAR)
         portions = [
@@ -548,5 +554,3 @@ class Dictionary:
             for portion in portions
         ]
         return LIST_HORIZONTAL_RESOLVING_CHAR.join(portions)
-
-        

--- a/pyxavi/storage.py
+++ b/pyxavi/storage.py
@@ -46,31 +46,45 @@ class Storage(Dictionary):
             yaml.safe_dump(self._content, stream)
 
     def get_hashed(self, param_name: str = "", default_value: any = None) -> any:
-        # if param_name.find(".") > 0:
-        #     last = param_name[-1]
-        #     param_name = param_name[0:-1]
-        #     param_name = param_name + sha256(last.encode()).hexdigest()
-        # else:
+        """
+        Gets a hashed parameter from the storage.
+        It is meant only for first level keys.
+        """
         param_name = sha256(param_name.encode()).hexdigest()
 
         return self.get(param_name, default_value)
 
     def set_hashed(self, param_name: str, value: any = None):
-        # if param_name.find(".") > 0:
-        #     last = param_name[-1]
-        #     param_name = param_name[0:-1]
-        #     param_name = param_name + sha256(last.encode()).hexdigest()
-        # else:
+        """
+        Sets a hashed parameter from the storage.
+        It is meant only for first level keys.
+        """
         param_name = sha256(param_name.encode()).hexdigest()
 
         self.set(param_name, value)
 
     def get_slugged(self, param_name: str = "", default_value: any = None) -> any:
+        """
+        Gets a slugified parameter from the storage.
+
+        It is meant only for first level keys.
+        For deeper level keys, use get() with the slugify_param_name parameter,
+            but keep in mind that the separator "." (as per fefault) will be respected,
+            so an URL won't be slugified as a whole.
+        """
         param_name = slugify(param_name)
 
         return self.get(param_name, default_value)
 
     def set_slugged(self, param_name: str, value: any = None):
+        """
+        Sets a slugified parameter from the storage.
+
+        It is meant only for first level keys.
+        For deeper level keys, use get() with the slugify_param_name parameter,
+            but keep in mind that the separator "." (as per fefault) will be respected,
+            so an URL won't be slugified as a whole.
+        """
         param_name = slugify(param_name)
 
         self.set(param_name, value)

--- a/tests/test_dictionary.py
+++ b/tests/test_dictionary.py
@@ -79,11 +79,9 @@ TEST_CASES = {
         },
     ],
     "2025-01-01": {
-        "00-00": "New Year",
-        "01:00": [
-            "New Year Party",
-            {"Fireworks": "Yes"}
-        ]
+        "00-00": "New Year", "01:00": ["New Year Party", {
+            "Fireworks": "Yes"
+        }]
     }
 }
 
@@ -245,7 +243,9 @@ def test_get(param_name, expected_result, slugify_param_name):
                 }, {
                     "g1": "x", "g2": "G2c", "g3": "G3c"
                 }
-            ], False),
+            ],
+            False
+        ),
         # Wildcards in the second and fourth level, which are a lists of dicts
         ("hhh.#.h3.#.hh3", "x", [{
             "hh3": "x"
@@ -263,7 +263,9 @@ def test_get(param_name, expected_result, slugify_param_name):
             "ii3": "x"
         }], False),
         # Slugified param name
-        ("2025/12/31.00:00", "Silvester", {"00-00": "Silvester"}, True)
+        ("2025/12/31.00:00", "Silvester", {
+            "00-00": "Silvester"
+        }, True)
     ]
 )
 def test_set(param_name, value, expected_result_parent, slugify_param_name):
@@ -272,11 +274,15 @@ def test_set(param_name, value, expected_result_parent, slugify_param_name):
 
     if expected_result_parent is False:
         with TestCase.assertRaises(instance, RuntimeError):
-            instance.set(param_name=param_name, value=value, slugify_param_name=slugify_param_name)
+            instance.set(
+                param_name=param_name, value=value, slugify_param_name=slugify_param_name
+            )
     else:
         instance.set(param_name=param_name, value=value, slugify_param_name=slugify_param_name)
-        
-        result_parent = instance.get_parent(param_name=param_name, slugify_param_name=slugify_param_name)
+
+        result_parent = instance.get_parent(
+            param_name=param_name, slugify_param_name=slugify_param_name
+        )
         dd(result_parent)
         _compare_results(result_parent, expected_result_parent)
 
@@ -382,18 +388,26 @@ def test_merge(param_name, origin, expected_result_parent):
 @pytest.mark.parametrize(
     argnames=('param_name', 'expected_result', 'slugify_param_name'),
     argvalues=[
-        ("foo", True, False), ("foo.bar", True, False), ("foo.bar5", False, False), ("foo.foo2", True, False),
-        ("foo.foo2.bar2", True, False), ("foo.foo2.bar2.nope", False, False),
-        ("foo.foo2.bar2.nope.nope2", False, False), ("food", False, False), ("void", True, False),
+        ("foo", True, False),
+        ("foo.bar", True, False),
+        ("foo.bar5", False, False),
+        ("foo.foo2", True, False),
+        ("foo.foo2.bar2", True, False),
+        ("foo.foo2.bar2.nope", False, False),
+        ("foo.foo2.bar2.nope.nope2", False, False),
+        ("food", False, False),
+        ("void", True, False),
         ("2025/01/01", True, True),
-        
     ]
 )
 def test_key_exists(param_name, expected_result, slugify_param_name):
 
     instance = initialize_instance()
 
-    assert instance.key_exists(param_name=param_name, slugify_param_name=slugify_param_name) == expected_result
+    assert instance.key_exists(
+        param_name=param_name, slugify_param_name=slugify_param_name
+    ) == expected_result
+
 
 @pytest.mark.parametrize(
     argnames=('param_name', 'expected_result', 'slugify_param_name'),
@@ -414,7 +428,9 @@ def test_get_parent(param_name, expected_result, slugify_param_name):
 
     instance = initialize_instance()
 
-    assert instance.get_parent(param_name=param_name, slugify_param_name=slugify_param_name) == expected_result
+    assert instance.get_parent(
+        param_name=param_name, slugify_param_name=slugify_param_name
+    ) == expected_result
 
 
 @pytest.mark.parametrize(
@@ -454,15 +470,21 @@ def test_delete(param_name, expected_delete, expected_result_parent, slugify_par
 
     instance = initialize_instance()
 
-    assert instance.delete(param_name=param_name, slugify_param_name=slugify_param_name) == expected_delete
+    assert instance.delete(
+        param_name=param_name, slugify_param_name=slugify_param_name
+    ) == expected_delete
 
     if expected_result_parent is not None:
         # One can't check if the item in the list is deleted by checking the key,
         #   as the rest of the items move in front.
         #   Deleting index 0 will not get rid of index 0, 1 becomes 0.
-        assert instance.get_parent(param_name=param_name, slugify_param_name=slugify_param_name) == expected_result_parent
+        assert instance.get_parent(
+            param_name=param_name, slugify_param_name=slugify_param_name
+        ) == expected_result_parent
     else:
-        assert instance.key_exists(param_name=param_name, slugify_param_name=slugify_param_name) is False
+        assert instance.key_exists(
+            param_name=param_name, slugify_param_name=slugify_param_name
+        ) is False
 
 
 @pytest.mark.parametrize(
@@ -522,7 +544,8 @@ def test_initialise_recursive(param_name, is_exception):
     argnames=('param_name', 'expected_result', 'slugify_param_name'),
     argvalues=[
         (
-            None, [
+            None,
+            [
                 "foo",
                 "que",
                 "void",
@@ -536,18 +559,31 @@ def test_initialise_recursive(param_name, is_exception):
                 "hhh",
                 "iii",
                 "2025-01-01"
-            ], False
-        ), ("ccc", ["ccc1", "ccc2", "ccc3"], False), ("ddd", ["ddd1", "ddd2", "ddd3"], False),
-        ("eee.e_set", [0, 1, 2], False), ("eee.e_tuple", [0, 1, 2], False), ("eee.e_list", [0, 1, 2], False),
-        ("fff.fff", [0, 1, 2], False), ("aaa", [0, 1, 2], False), ("aaa.0", None, False), ("aaa.5", None, False),
-        ("bbb.b2.1", ["bb2b1"], False), ("bbb.b2.5.bb2b1", None, False), ("2025/01/01", ["00-00", "01:00"], True),
+            ],
+            False
+        ),
+        ("ccc", ["ccc1", "ccc2", "ccc3"], False),
+        ("ddd", ["ddd1", "ddd2", "ddd3"], False),
+        ("eee.e_set", [0, 1, 2], False),
+        ("eee.e_tuple", [0, 1, 2], False),
+        ("eee.e_list", [0, 1, 2], False),
+        ("fff.fff", [0, 1, 2], False),
+        ("aaa", [0, 1, 2], False),
+        ("aaa.0", None, False),
+        ("aaa.5", None, False),
+        ("bbb.b2.1", ["bb2b1"], False),
+        ("bbb.b2.5.bb2b1", None, False),
+        ("2025/01/01", ["00-00", "01:00"], True),
     ]
 )
 def test_get_keys_in(param_name, expected_result, slugify_param_name):
 
     instance = initialize_instance()
 
-    assert instance.get_keys_in(param_name=param_name, slugify_param_name=slugify_param_name) == expected_result
+    assert instance.get_keys_in(
+        param_name=param_name, slugify_param_name=slugify_param_name
+    ) == expected_result
+
 
 def test_to_dict():
 
@@ -588,7 +624,10 @@ def test_resolve_wildcards(param_name, expected_result, slugify_param_name):
 
     instance = initialize_instance()
 
-    assert instance.resolve_wildcards(param_name=param_name, slugify_param_name=slugify_param_name) == expected_result
+    assert instance.resolve_wildcards(
+        param_name=param_name, slugify_param_name=slugify_param_name
+    ) == expected_result
+
 
 @pytest.mark.parametrize(
     argnames=('param_name', 'expected_result', 'slugify_param_name'),
@@ -606,7 +645,9 @@ def test_last_key(param_name, expected_result, slugify_param_name):
 
     instance = initialize_instance()
 
-    assert instance.get_last_key(param_name=param_name, slugify_param_name=slugify_param_name) == expected_result
+    assert instance.get_last_key(
+        param_name=param_name, slugify_param_name=slugify_param_name
+    ) == expected_result
 
 
 @pytest.mark.parametrize(

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,6 +1,5 @@
 from unittest.mock import patch, mock_open
 from pyxavi import Storage
-from unittest import TestCase
 import pytest
 
 FILE = {

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -179,10 +179,15 @@ def test_set_third_level_old_value():
 
 
 def test_set_bad_key():
+    # Behaviour changed in 1.3.0 -> now creates the missing keys
     instance = initialize()
 
-    with TestCase.assertRaises(instance, RuntimeError):
-        instance.set("foo.foo3.bar2", 99)
+    # `foo3` is a not existing key.
+    # with TestCase.assertRaises(instance, RuntimeError):
+    #     instance.set("foo.foo3.bar2", 99)
+
+    instance.set("foo.foo3.bar2", 99)
+    assert instance.get("foo.foo3.bar2") == 99
 
 
 def test_get_hashed():


### PR DESCRIPTION
Adding a parameter that slugifies the parameter name parts before trying to access the state. Useful for keys that contain invalid chars for a key.

Also fixing a historical issue where `set()` won't create a key if any of the parameters name parts is missing as a key in the state 